### PR TITLE
Fix navigation bar active page highlighting

### DIFF
--- a/micasita-clone/package-lock.json
+++ b/micasita-clone/package-lock.json
@@ -26,6 +26,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.4.6",
+        "lightningcss-linux-x64-gnu": "^1.30.1",
         "tailwindcss": "^4.1.11",
         "typescript": "^5"
       }
@@ -3535,6 +3536,26 @@
         "lightningcss-linux-x64-musl": "1.30.1",
         "lightningcss-win32-arm64-msvc": "1.30.1",
         "lightningcss-win32-x64-msvc": "1.30.1"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {

--- a/micasita-clone/package.json
+++ b/micasita-clone/package.json
@@ -27,6 +27,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.4.6",
+    "lightningcss-linux-x64-gnu": "^1.30.1",
     "tailwindcss": "^4.1.11",
     "typescript": "^5"
   }

--- a/micasita-clone/src/components/Header.tsx
+++ b/micasita-clone/src/components/Header.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
 
 interface HeaderTabProps {
   label: string;
@@ -8,8 +10,9 @@ interface HeaderTabProps {
 
 const HeaderTab: React.FC<HeaderTabProps> = ({ label, href, isActive = false }) => {
   return (
-    <a
+    <Link
       href={href}
+      aria-current={isActive ? 'page' : undefined}
       className={`px-4 py-2 text-sm font-medium transition-colors duration-200 ${
         isActive
           ? 'text-blue-600 border-b-2 border-blue-600'
@@ -17,7 +20,7 @@ const HeaderTab: React.FC<HeaderTabProps> = ({ label, href, isActive = false }) 
       }`}
     >
       {label}
-    </a>
+    </Link>
   );
 };
 
@@ -29,8 +32,11 @@ const Header: React.FC = () => {
     { label: 'Staff', href: '/staff' },
     { label: 'Links', href: '/links' },
     { label: 'Contact Us', href: '/contact' },
-    { label: 'eCashier', href: '/ecashier' }
+    { label: 'eCashier', href: '/eCashier' }
   ];
+
+  const router = useRouter();
+  const currentPath = router.pathname;
 
   return (
     <header className="bg-white shadow-sm border-b border-gray-200">
@@ -52,19 +58,19 @@ const Header: React.FC = () => {
                 key={index}
                 label={tab.label}
                 href={tab.href}
-                isActive={tab.href === '/'} // You can make this dynamic based on current route
+                isActive={currentPath === tab.href}
               />
             ))}
           </nav>
 
           {/* eCashier Button Section */}
           <div className="flex items-center">
-            <a 
+            <Link 
               href="/eCashier" 
               className="bg-red-600 hover:bg-red-700 text-white font-medium py-2 px-4 rounded-md transition-colors duration-200"
             >
               eCashier
-            </a>
+            </Link>
           </div>
         </div>
       </div>

--- a/micasita-clone/src/pages/request-change.tsx
+++ b/micasita-clone/src/pages/request-change.tsx
@@ -43,7 +43,7 @@ const RequestChangePage: React.FC = () => {
           <div className="bg-white rounded-lg shadow-md p-6 mb-8">
             <p className="text-lg text-gray-600 mb-4">
               Help us keep our website current and accurate by submitting content change requests. 
-              Whether you've found outdated information, broken links, or have suggestions for improvements, 
+              Whether you&#39;ve found outdated information, broken links, or have suggestions for improvements, 
               we appreciate your feedback.
             </p>
             <div className="bg-blue-50 border-l-4 border-blue-400 p-4">


### PR DESCRIPTION
Fix navigation bar to correctly highlight the active page based on the current route, resolving an issue where only the home page was marked active.

The `Header.tsx` component's `isActive` logic was hardcoded to `tab.href === '/'`. This PR updates `Header.tsx` to use `next/router` to determine the current path and dynamically set the active state for navigation tabs. All navigation links, including the 'eCashier' button, have been converted to `next/link` components. Additionally, a linting error in `request-change.tsx` (unescaped apostrophe) was fixed, and `lightningcss-linux-x64-gnu` was added to `package.json` to address a build dependency.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ad05830-a8e5-48d5-ac99-2711f004bfb4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1ad05830-a8e5-48d5-ac99-2711f004bfb4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

